### PR TITLE
Remove trailing commas in collection literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## [1.0.7]
+
+- Remove trailing commas in collection literals
+
+## [1.0.6]
+
+- Exclude gemspecs from MethodCallWithArgsParentheses
+
 ## [1.0.5]
 
 - Update minimum rubocop version
@@ -20,7 +28,7 @@
 
 ## [1.0.1]
 
-- Baseline Rubocop config from the Shopify one https://shopify.github.io/ruby-style-guide/rubocop.yml
+- Baseline Rubocop config from the Shopify one <https://shopify.github.io/ruby-style-guide/rubocop.yml>
 
 ## [1.0.0]
 

--- a/rewind-ruby-style.gemspec
+++ b/rewind-ruby-style.gemspec
@@ -1,24 +1,24 @@
 # frozen_string_literal: true
 
 Gem::Specification.new do |s|
-    s.platform    = Gem::Platform::RUBY
-    s.name        = "rewind-ruby-style"
-    s.version     = "1.0.6"
-    s.summary     = "Rewind's style guide for Ruby."
-    s.description = "Gem containing the config files for style chekers that corresponds to "\
-      "the implementation of the Rewind style guide for Ruby."
-  
-    s.license = "MIT"
-  
-    s.author   = "Rewind Devops"
-    s.email    = "team@rewind.io"
-    s.homepage = "https://github.com/rewindio/ruby-style-configs/"
-  
-    s.files = ["rubocop.yml", "reek.yml"]
-  
-    s.metadata = {
-      "source_code_uri" => "https://github.com/rewindio/ruby-style-configs/tree/v#{s.version}"
-    }
-  
-    s.add_dependency("rubocop", ">= 0.85", "< 0.89")
-  end
+  s.platform = Gem::Platform::RUBY
+  s.name        = 'rewind-ruby-style'
+  s.version     = '1.0.7'
+  s.summary     = "Rewind's style guide for Ruby."
+  s.description = 'Gem containing the config files for style chekers that corresponds to '\
+    'the implementation of the Rewind style guide for Ruby.'
+
+  s.license = 'MIT'
+
+  s.author   = 'Rewind Devops'
+  s.email    = 'team@rewind.io'
+  s.homepage = 'https://github.com/rewindio/ruby-style-configs/'
+
+  s.files = ['rubocop.yml', 'reek.yml']
+
+  s.metadata = {
+    'source_code_uri' => "https://github.com/rewindio/ruby-style-configs/tree/v#{s.version}"
+  }
+
+  s.add_dependency('rubocop', '>= 0.85', '< 0.89')
+end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -3,14 +3,14 @@ AllCops:
   TargetRubyVersion: 2.6
   StyleGuideBaseURL: https://github.com/rewindio/ruby-style-configs/
   Exclude:
-    - '.ebextenstions/**/*'
-    - '.git/**/*'
-    - 'bin/**/*'
-    - 'certs/**/*'
-    - 'db/**/*'
-    - 'log/**/*'
-    - 'tmp/**/*'
-    - 'vendor/**/*'
+    - ".ebextenstions/**/*"
+    - ".git/**/*"
+    - "bin/**/*"
+    - "certs/**/*"
+    - "db/**/*"
+    - "log/**/*"
+    - "tmp/**/*"
+    - "vendor/**/*"
   DisabledByDefault: true
 
 Lint/AssignmentInCondition:
@@ -19,127 +19,127 @@ Lint/AssignmentInCondition:
 Layout/AccessModifierIndentation:
   EnforcedStyle: indent
   SupportedStyles:
-  - outdent
-  - indent
+    - outdent
+    - indent
   IndentationWidth:
 
 Style/Alias:
   EnforcedStyle: prefer_alias_method
   SupportedStyles:
-  - prefer_alias
-  - prefer_alias_method
+    - prefer_alias
+    - prefer_alias_method
 
 Layout/HashAlignment:
   EnforcedHashRocketStyle: key
   EnforcedColonStyle: key
   EnforcedLastArgumentHashStyle: ignore_implicit
   SupportedLastArgumentHashStyles:
-  - always_inspect
-  - always_ignore
-  - ignore_implicit
-  - ignore_explicit
+    - always_inspect
+    - always_ignore
+    - ignore_implicit
+    - ignore_explicit
 
 Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
   SupportedStyles:
-  - with_first_parameter
-  - with_fixed_indentation
+    - with_first_parameter
+    - with_fixed_indentation
   IndentationWidth:
 
 Style/AndOr:
   EnforcedStyle: always
   SupportedStyles:
-  - always
-  - conditionals
+    - always
+    - conditionals
 
 Style/BarePercentLiterals:
   EnforcedStyle: bare_percent
   SupportedStyles:
-  - percent_q
-  - bare_percent
+    - percent_q
+    - bare_percent
 
 Style/BlockDelimiters:
   EnforcedStyle: line_count_based
   SupportedStyles:
-  - line_count_based
-  - semantic
-  - braces_for_chaining
+    - line_count_based
+    - semantic
+    - braces_for_chaining
   ProceduralMethods:
-  - benchmark
-  - bm
-  - bmbm
-  - create
-  - each_with_object
-  - measure
-  - new
-  - realtime
-  - tap
-  - with_object
+    - benchmark
+    - bm
+    - bmbm
+    - create
+    - each_with_object
+    - measure
+    - new
+    - realtime
+    - tap
+    - with_object
   FunctionalMethods:
-  - let
-  - let!
-  - subject
-  - watch
+    - let
+    - let!
+    - subject
+    - watch
   IgnoredMethods:
-  - lambda
-  - proc
-  - it
+    - lambda
+    - proc
+    - it
 
 Layout/CaseIndentation:
   EnforcedStyle: end
   SupportedStyles:
-  - case
-  - end
+    - case
+    - end
   IndentOneStep: false
   IndentationWidth:
 
 Style/ClassAndModuleChildren:
   EnforcedStyle: nested
   SupportedStyles:
-  - nested
-  - compact
+    - nested
+    - compact
 
 Style/ClassCheck:
   EnforcedStyle: is_a?
   SupportedStyles:
-  - is_a?
-  - kind_of?
+    - is_a?
+    - kind_of?
 
 Style/CommandLiteral:
   EnforcedStyle: percent_x
   SupportedStyles:
-  - backticks
-  - percent_x
-  - mixed
+    - backticks
+    - percent_x
+    - mixed
   AllowInnerBackticks: false
 
 Style/CommentAnnotation:
   Keywords:
-  - TODO
-  - FIXME
-  - OPTIMIZE
-  - HACK
-  - REVIEW
+    - TODO
+    - FIXME
+    - OPTIMIZE
+    - HACK
+    - REVIEW
 
 Style/ConditionalAssignment:
   EnforcedStyle: assign_to_condition
   SupportedStyles:
-  - assign_to_condition
-  - assign_inside_condition
+    - assign_to_condition
+    - assign_inside_condition
   SingleLineConditionsOnly: true
 
 Layout/DotPosition:
   EnforcedStyle: leading
   SupportedStyles:
-  - leading
-  - trailing
+    - leading
+    - trailing
 
 Style/EmptyElse:
   EnforcedStyle: both
   SupportedStyles:
-  - empty
-  - nil
-  - both
+    - empty
+    - nil
+    - both
 
 Layout/EmptyLineBetweenDefs:
   AllowAdjacentOneLineDefs: false
@@ -147,22 +147,22 @@ Layout/EmptyLineBetweenDefs:
 Layout/EmptyLinesAroundBlockBody:
   EnforcedStyle: no_empty_lines
   SupportedStyles:
-  - empty_lines
-  - no_empty_lines
+    - empty_lines
+    - no_empty_lines
 
 Layout/EmptyLinesAroundClassBody:
   EnforcedStyle: no_empty_lines
   SupportedStyles:
-  - empty_lines
-  - empty_lines_except_namespace
-  - no_empty_lines
+    - empty_lines
+    - empty_lines_except_namespace
+    - no_empty_lines
 
 Layout/EmptyLinesAroundModuleBody:
   EnforcedStyle: no_empty_lines
   SupportedStyles:
-  - empty_lines
-  - empty_lines_except_namespace
-  - no_empty_lines
+    - empty_lines
+    - empty_lines_except_namespace
+    - no_empty_lines
 
 Layout/ExtraSpacing:
   AllowForAlignment: true
@@ -177,23 +177,23 @@ Naming/FileName:
 Layout/FirstArgumentIndentation:
   EnforcedStyle: consistent
   SupportedStyles:
-  - consistent
-  - special_for_inner_method_call
-  - special_for_inner_method_call_in_parentheses
+    - consistent
+    - special_for_inner_method_call
+    - special_for_inner_method_call_in_parentheses
   IndentationWidth:
 
 Style/For:
   EnforcedStyle: each
   SupportedStyles:
-  - for
-  - each
+    - for
+    - each
 
 Style/FormatString:
   EnforcedStyle: format
   SupportedStyles:
-  - format
-  - sprintf
-  - percent
+    - format
+    - sprintf
+    - percent
 
 Style/FrozenStringLiteralComment:
   Details: >-
@@ -211,18 +211,18 @@ Style/GlobalVars:
 Style/HashSyntax:
   EnforcedStyle: ruby19
   SupportedStyles:
-  - ruby19
-  - hash_rockets
-  - no_mixed_keys
-  - ruby19_no_mixed_keys
+    - ruby19
+    - hash_rockets
+    - no_mixed_keys
+    - ruby19_no_mixed_keys
   UseHashRocketsWithSymbolValues: false
   PreferHashRocketsForNonAlnumEndingSymbols: false
 
 Layout/IndentationConsistency:
   EnforcedStyle: normal
   SupportedStyles:
-  - normal
-  - rails
+    - normal
+    - rails
 
 Layout/IndentationWidth:
   Width: 2
@@ -230,9 +230,9 @@ Layout/IndentationWidth:
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
   SupportedStyles:
-  - special_inside_parentheses
-  - consistent
-  - align_brackets
+    - special_inside_parentheses
+    - consistent
+    - align_brackets
   IndentationWidth:
 
 Layout/AssignmentIndentation:
@@ -241,23 +241,23 @@ Layout/AssignmentIndentation:
 Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
   SupportedStyles:
-  - special_inside_parentheses
-  - consistent
-  - align_braces
+    - special_inside_parentheses
+    - consistent
+    - align_braces
   IndentationWidth:
 
 Style/LambdaCall:
   EnforcedStyle: call
   SupportedStyles:
-  - call
-  - braces
+    - call
+    - braces
 
 Style/Next:
   EnforcedStyle: skip_modifier_ifs
   MinBodyLength: 3
   SupportedStyles:
-  - skip_modifier_ifs
-  - always
+    - skip_modifier_ifs
+    - always
 
 Style/NonNilCheck:
   IncludeSemanticChanges: false
@@ -266,74 +266,74 @@ Style/MethodCallWithArgsParentheses:
   Enabled: true
   IgnoreMacros: true
   IgnoredMethods:
-  - require
-  - require_relative
-  - require_dependency
-  - yield
-  - raise
-  - puts
+    - require
+    - require_relative
+    - require_dependency
+    - yield
+    - raise
+    - puts
   Exclude:
-  - Gemfile
-  - Gemfile.*
-  - '**/**/Gemfile'
-  - '**/**/Gemfile.*'
-  - '*.gemspec'
-  - '**/**/*.gemspec'
+    - Gemfile
+    - Gemfile.*
+    - "**/**/Gemfile"
+    - "**/**/Gemfile.*"
+    - "*.gemspec"
+    - "**/**/*.gemspec"
 
 Style/MethodDefParentheses:
   EnforcedStyle: require_parentheses
   SupportedStyles:
-  - require_parentheses
-  - require_no_parentheses
-  - require_no_parentheses_except_multiline
+    - require_parentheses
+    - require_no_parentheses
+    - require_no_parentheses_except_multiline
 
 Naming/MethodName:
   EnforcedStyle: snake_case
   SupportedStyles:
-  - snake_case
-  - camelCase
+    - snake_case
+    - camelCase
 
 Layout/MultilineArrayBraceLayout:
   EnforcedStyle: symmetrical
   SupportedStyles:
-  - symmetrical
-  - new_line
-  - same_line
+    - symmetrical
+    - new_line
+    - same_line
 
 Layout/MultilineHashBraceLayout:
   EnforcedStyle: symmetrical
   SupportedStyles:
-  - symmetrical
-  - new_line
-  - same_line
+    - symmetrical
+    - new_line
+    - same_line
 
 Layout/MultilineMethodCallBraceLayout:
   EnforcedStyle: symmetrical
   SupportedStyles:
-  - symmetrical
-  - new_line
-  - same_line
+    - symmetrical
+    - new_line
+    - same_line
 
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
   SupportedStyles:
-  - aligned
-  - indented
-  - indented_relative_to_receiver
+    - aligned
+    - indented
+    - indented_relative_to_receiver
   IndentationWidth: 2
 
 Layout/MultilineMethodDefinitionBraceLayout:
   EnforcedStyle: symmetrical
   SupportedStyles:
-  - symmetrical
-  - new_line
-  - same_line
+    - symmetrical
+    - new_line
+    - same_line
 
 Style/NumericLiteralPrefix:
   EnforcedOctalStyle: zero_only
   SupportedOctalStyles:
-  - zero_with_o
-  - zero_only
+    - zero_with_o
+    - zero_only
 
 Style/ParenthesesAroundCondition:
   AllowSafeAssignment: true
@@ -341,30 +341,30 @@ Style/ParenthesesAroundCondition:
 Style/PercentQLiterals:
   EnforcedStyle: lower_case_q
   SupportedStyles:
-  - lower_case_q
-  - upper_case_q
+    - lower_case_q
+    - upper_case_q
 
 Naming/PredicateName:
   NamePrefix:
-  - is_
+    - is_
   ForbiddenPrefixes:
-  - is_
+    - is_
   AllowedMethods:
-  - is_a?
+    - is_a?
   Exclude:
-  - 'spec/**/*'
+    - "spec/**/*"
 
 Style/PreferredHashMethods:
   EnforcedStyle: short
   SupportedStyles:
-  - short
-  - verbose
+    - short
+    - verbose
 
 Style/RaiseArgs:
   EnforcedStyle: exploded
   SupportedStyles:
-  - compact
-  - exploded
+    - compact
+    - exploded
 
 Style/RedundantReturn:
   AllowMultipleReturnValues: false
@@ -372,9 +372,9 @@ Style/RedundantReturn:
 Style/RegexpLiteral:
   EnforcedStyle: mixed
   SupportedStyles:
-  - slashes
-  - percent_r
-  - mixed
+    - slashes
+    - percent_r
+    - mixed
   AllowInnerSlashes: false
 
 Style/SafeNavigation:
@@ -390,9 +390,9 @@ Style/Semicolon:
 Style/SignalException:
   EnforcedStyle: only_raise
   SupportedStyles:
-  - only_raise
-  - only_fail
-  - semantic
+    - only_raise
+    - only_fail
+    - semantic
 
 Style/SingleLineMethods:
   AllowIfMethodIsEmpty: true
@@ -403,32 +403,32 @@ Layout/SpaceBeforeFirstArg:
 Style/SpecialGlobalVars:
   EnforcedStyle: use_english_names
   SupportedStyles:
-  - use_perl_names
-  - use_english_names
+    - use_perl_names
+    - use_english_names
 
 Style/StabbyLambdaParentheses:
   EnforcedStyle: require_parentheses
   SupportedStyles:
-  - require_parentheses
-  - require_no_parentheses
+    - require_parentheses
+    - require_no_parentheses
 
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: single_quotes
   SupportedStyles:
-  - single_quotes
-  - double_quotes
+    - single_quotes
+    - double_quotes
 
 Layout/SpaceAroundBlockParameters:
   EnforcedStyleInsidePipes: no_space
   SupportedStylesInsidePipes:
-  - space
-  - no_space
+    - space
+    - no_space
 
 Layout/SpaceAroundEqualsInParameterDefault:
   EnforcedStyle: space
   SupportedStyles:
-  - space
-  - no_space
+    - space
+    - no_space
 
 Layout/SpaceAroundOperators:
   AllowForAlignment: true
@@ -437,14 +437,14 @@ Layout/SpaceBeforeBlockBraces:
   EnforcedStyle: space
   EnforcedStyleForEmptyBraces: space
   SupportedStyles:
-  - space
-  - no_space
+    - space
+    - no_space
 
 Layout/SpaceInsideBlockBraces:
   EnforcedStyle: space
   SupportedStyles:
-  - space
-  - no_space
+    - space
+    - no_space
   EnforcedStyleForEmptyBraces: no_space
   SpaceBeforeBlockParameters: true
 
@@ -452,33 +452,33 @@ Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: space
   EnforcedStyleForEmptyBraces: no_space
   SupportedStyles:
-  - space
-  - no_space
-  - compact
+    - space
+    - no_space
+    - compact
 
 Layout/SpaceInsideStringInterpolation:
   EnforcedStyle: no_space
   SupportedStyles:
-  - space
-  - no_space
+    - space
+    - no_space
 
 Style/SymbolProc:
   IgnoredMethods:
-  - respond_to
-  - define_method
+    - respond_to
+    - define_method
 
 Style/TernaryParentheses:
   EnforcedStyle: require_no_parentheses
   SupportedStyles:
-  - require_parentheses
-  - require_no_parentheses
+    - require_parentheses
+    - require_no_parentheses
   AllowSafeAssignment: true
 
 Layout/TrailingEmptyLines:
   EnforcedStyle: final_newline
   SupportedStyles:
-  - final_newline
-  - final_blank_line
+    - final_newline
+    - final_blank_line
 
 Style/TrivialAccessors:
   ExactNameMatch: true
@@ -486,29 +486,29 @@ Style/TrivialAccessors:
   AllowDSLWriters: false
   IgnoreClassMethods: false
   AllowedMethods:
-  - to_ary
-  - to_a
-  - to_c
-  - to_enum
-  - to_h
-  - to_hash
-  - to_i
-  - to_int
-  - to_io
-  - to_open
-  - to_path
-  - to_proc
-  - to_r
-  - to_regexp
-  - to_str
-  - to_s
-  - to_sym
+    - to_ary
+    - to_a
+    - to_c
+    - to_enum
+    - to_h
+    - to_hash
+    - to_i
+    - to_int
+    - to_io
+    - to_open
+    - to_path
+    - to_proc
+    - to_r
+    - to_regexp
+    - to_str
+    - to_s
+    - to_sym
 
 Naming/VariableName:
   EnforcedStyle: snake_case
   SupportedStyles:
-  - snake_case
-  - camelCase
+    - snake_case
+    - camelCase
 
 Style/WhileUntilModifier:
   Enabled: true
@@ -521,11 +521,11 @@ Layout/LineLength:
   AllowHeredoc: true
   AllowURI: true
   URISchemes:
-  - http
-  - https
+    - http
+    - https
   IgnoreCopDirectives: false
   IgnoredPatterns:
-  - '\A\s*(remote_)?test(_\w+)?\s.*(do|->)(\s|\Z)'
+    - '\A\s*(remote_)?test(_\w+)?\s.*(do|->)(\s|\Z)'
 
 Metrics/ParameterLists:
   Max: 5
@@ -534,28 +534,28 @@ Metrics/ParameterLists:
 Layout/BlockAlignment:
   EnforcedStyleAlignWith: either
   SupportedStylesAlignWith:
-  - either
-  - start_of_block
-  - start_of_line
+    - either
+    - start_of_block
+    - start_of_line
 
 Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
   SupportedStylesAlignWith:
-  - keyword
-  - variable
-  - start_of_line
+    - keyword
+    - variable
+    - start_of_line
 
 Layout/DefEndAlignment:
   EnforcedStyleAlignWith: start_of_line
   SupportedStylesAlignWith:
-  - start_of_line
-  - def
+    - start_of_line
+    - def
 
 Lint/InheritException:
   EnforcedStyle: runtime_error
   SupportedStyles:
-  - runtime_error
-  - standard_error
+    - runtime_error
+    - standard_error
 
 Lint/UnusedBlockArgument:
   IgnoreEmptyBlocks: true
@@ -904,7 +904,8 @@ Lint/ImplicitStringConcatenation:
     better be represented as a single string literal.
 
 Lint/IneffectiveAccessModifier:
-  Description: Checks for attempts to use `private` or `protected` to set the visibility
+  Description:
+    Checks for attempts to use `private` or `protected` to set the visibility
     of a class method, which does not work.
 
 Lint/LiteralAsCondition:
@@ -914,14 +915,16 @@ Lint/LiteralInInterpolation:
   Enabled: true
 
 Lint/Loop:
-  Description: Use Kernel#loop with break rather than begin/end/until or begin/end/while
+  Description:
+    Use Kernel#loop with break rather than begin/end/until or begin/end/while
     for post-loop tests.
 
 Lint/NestedMethodDefinition:
   Enabled: true
 
 Lint/NextWithoutAccumulator:
-  Description: Do not omit the accumulator when calling `next` in a `reduce`/`inject`
+  Description:
+    Do not omit the accumulator when calling `next` in a `reduce`/`inject`
     block.
 
 Lint/NonLocalExitFromIterator:
@@ -1013,11 +1016,11 @@ Style/TrailingBodyOnModule:
   Enabled: true
 
 Style/TrailingCommaInArrayLiteral:
-  EnforcedStyleForMultiline: comma
+  EnforcedStyleForMultiline: no_comma
   Enabled: true
 
 Style/TrailingCommaInHashLiteral:
-  EnforcedStyleForMultiline: comma
+  EnforcedStyleForMultiline: no_comma
   Enabled: true
 
 Layout/SpaceInsideReferenceBrackets:


### PR DESCRIPTION
## Description of change
I am on the no trailing commas boat.
https://metaredux.com/posts/2020/05/26/rubocop-defaults-survey-results.html
https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/TrailingCommaInHashLiteral

My yaml formatter also went to town 😬 

## Testing Performed
rubocop -a using these rules