### PR TITLE
Enable Lint/Debugger cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [1.0.10]
+
+- Enable the Lint/Debugger cop (checks for pry)
+
 ## [1.0.9]
 
 - Revert to more permissive config (for now)

--- a/rewind-ruby-style.gemspec
+++ b/rewind-ruby-style.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.name        = 'rewind-ruby-style'
-  s.version     = '1.0.9'
+  s.version     = '1.0.10'
   s.summary     = "Rewind's style guide for Ruby."
   s.description = 'Gem containing the config files for style chekers that corresponds to '\
     'the implementation of the Rewind style guide for Ruby.'

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -84,3 +84,6 @@ Style/NumericPredicate:
 
 Lint/SuppressedException:
   AllowComments: true
+
+Lint/Debugger:
+  Enabled: true


### PR DESCRIPTION
## Description of change

Enable the Cop that checks for pry or byebug (https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/Debugger)

